### PR TITLE
Rework.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ client component of the Nagios-like Check_MK monitoring suite.
 This role requires at least Ansible `v1.7.0`. To install it, clone it
 to your [DebOps](http://debops.org) project roles directory:
 
-    git clone http://github.com/ganto/ansible-checkmk_agent.git
+    git clone https://github.com/debops-contrib/ansible-checkmk_agent.git
 
 
 ### Role dependencies

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,11 +15,23 @@
 # Valid options are ``ssh`` and ``xinetd``.
 checkmk_agent: [ 'xinetd' ]
 
+
 # .. envvar:: checkmk_agent_allow
 #
-# Lists of IP addresses or network CIDR ranges allowed to connect to the
-# Check_MK agent through the firewall. If lists are empty, anyone can connect.
+# List of IP addresses or network CIDR ranges allowed to connect to the
+# Check_MK agent through the firewall. If list are empty, anyone can connect.
 checkmk_agent_allow: []
+
+
+# .. envvar:: checkmk_agent_ferm_dependent_rules
+#
+# Configuration of the Linux firewall using ``debops.ferm``.
+checkmk_agent_ferm_dependent_rules:
+  - type: 'accept'
+    dport: [ 'check-mk-agent' ]
+    saddr: '{{ checkmk_agent_allow }}'
+    accept_any: True
+    weight: '20'
 
 
 # ------------------------
@@ -31,6 +43,7 @@ checkmk_agent_allow: []
 # Check_MK agent executable path. If you query the agent from multiple
 # servers, you may want to set this to ``/usr/bin/check_mk_caching_agent``.
 checkmk_agent_exec: '/usr/bin/check_mk_agent'
+
 
 # .. envvar:: checkmk_agent_port
 #
@@ -47,15 +60,18 @@ checkmk_agent_port: '6556'
 # SSH user to query Check_MK agent.
 checkmk_agent_ssh_user: 'nagios'
 
+
 # .. envvar:: checkmk_agent_ssh_group
 #
 # Primary group of SSH user querying Check_MK agent.
 checkmk_agent_ssh_group: 'nagios'
 
+
 # .. envvar:: checkmk_agent_user_home
 #
 # Home directory of SSH user querying Check_MK agent.
 checkmk_agent_user_home: '/var/lib/nagios'
+
 
 # .. envvar:: checkmk_agent_user_key
 #
@@ -72,21 +88,25 @@ checkmk_agent_user_key: ''
 # List of upstream Check_MK agent plugins to always enable.
 checkmk_agent_plugins: []
 
+
 # .. envvar:: checkmk_agent_group_plugins
 #
 # "Host Group" list of upstream Check_MK agent plugins to always enable.
 checkmk_agent_group_plugins: []
+
 
 # .. envvar:: checkmk_agent_host_plugins
 #
 # "Host" list of upstream Check_MK agent plugins to always enable.
 checkmk_agent_host_plugins: []
 
+
 # .. envvar:: checkmk_agent_plugins_autodetect
 #
-# Try to install Check_MK agent plugins for applications autodetected
+# Try to install Check_MK agent plugins for applications auto detected
 # via DebOps host group memberships.
 checkmk_agent_plugin_autodetect: True
+
 
 # .. envvar:: checkmk_agent_plugins_path
 #
@@ -103,10 +123,12 @@ checkmk_agent_plugin_path: '/usr/lib/check_mk_agent/plugins'
 # Check_MK agent source repository.
 checkmk_agent_git_repo: 'http://git.mathias-kettner.de/check_mk.git'
 
+
 # .. envvar:: checkmk_agent_git_dest
 #
 # Check_MK agent source directory on the host.
 checkmk_agent_git_dest: '{{ "/usr/local/src/check-mk/" + checkmk_agent_git_repo.split("://")[1] }}'
+
 
 # .. envvar:: checkmk_agent_git_version
 #

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -4,7 +4,7 @@ Installation
 This role requires at least Ansible ``v1.7.0``. To install it, clone it
 to your `DebOps`_ project roles directory::
 
-    git clone http://github.com/ganto/ansible-checkmk_agent.git
+    git clone https://github.com/debops-contrib/ansible-checkmk_agent.git
 
 :: _DebOps: http://debops.org/
 

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -2,7 +2,7 @@ Introduction
 ============
 
 This `Ansible`_ role allows you to install and manage the `Check_MK`_
-agent. It is the client component of the nagios-based Check_MK monitoring
+agent. It is the client component of the Nagios-based Check_MK monitoring
 suite.
 
 .. _Ansible: http://ansible.com/

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -2,31 +2,28 @@
 
 dependencies:
   - role: debops.apt_preferences
-    tags: apt_preferences
+    tags: [ 'depend::apt_preferences', 'depend::apt_preferences:checkmk_agent',
+            'depend-of::checkmk_agent', 'type::dependency' ]
     apt_preferences_dependent_list:
       - package: 'check-mk'
         backports: [ 'jessie' ]
         reason: 'Package not available in stable Debian Jessie'
-        by_role: 'ansible-checkmk_agent'
+        by_role: 'debops.contrib-checkmk_agent'
 
   - role: debops.etc_services
+    tags: [ 'depend::etc_services', 'depend::etc_services:checkmk_agent',
+            'depend-of::checkmk_agent', 'type::dependency' ]
     etc_services_dependent_list:
       - name: 'check-mk-agent'
         port: '{{ checkmk_agent_port }}'
         comment: 'Check_MK agent (via xinetd)'
-    when: (checkmk_agent is defined and checkmk_agent) and
-          ('xinetd' in checkmk_agent)
+    when: (checkmk_agent|d() and 'xinetd' in checkmk_agent)
 
   - role: debops.ferm
-    ferm_input_list:
-      - type: 'dport_accept'
-        dport: [ 'check-mk-agent' ]
-        saddr: '{{ checkmk_agent_allow }}'
-        accept_any: True
-        filename: 'checkmk_agent_dependency_accept'
-        weight: '20'
-    when: (checkmk_agent is defined and checkmk_agent) and
-          ('xinetd' in checkmk_agent)
+    tags: [ 'depend::ferm', 'depend::ferm:checkmk_agent',
+            'depend-of::checkmk_agent', 'type::dependency' ]
+    ferm_dependent_rules: '{{ checkmk_agent_ferm_dependent_rules }}'
+    when: (checkmk_agent|d() and 'xinetd' in checkmk_agent)
 
 
 galaxy_info:

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -28,7 +28,7 @@ dependencies:
 
 galaxy_info:
   author: 'Reto Gantenbein'
-  description: 'Install Check_MK Agent'
+  description: 'Setup Check_MK monitoring agent'
   license: 'GNU General Public License v3'
   min_ansible_version: '1.7.0'
   platforms:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -32,17 +32,15 @@
   when: checkmk_agent is defined and checkmk_agent
 
 - include: ssh_user.yml
-  when: (checkmk_agent is defined and checkmk_agent) and
-        ('ssh' in checkmk_agent)
+  when: (checkmk_agent|d() and 'ssh' in checkmk_agent)
 
 - include: xinetd.yml
-  when: (checkmk_agent is defined and checkmk_agent) and
-        ('xinetd' in checkmk_agent)
+  when: (checkmk_agent|d() and 'xinetd' in checkmk_agent)
 
 - include: setup_plugins.yml
-  when: (checkmk_agent is defined and checkmk_agent) and
-        (ansible_local.checkmk_agent.checkmk_agent_plugin_list is defined and
-         ansible_local.checkmk_agent.checkmk_agent_plugin_list)
+  when: (checkmk_agent|d() and
+         ansible_local|d() and ansible_local.checkmk_agent|d() and
+         ansible_local.checkmk_agent.checkmk_agent_plugin_list|d())
 
 - name: DebOps post_tasks hook
   include: "{{ lookup('task_src', 'checkmk_agent/post_main.yml') }}"

--- a/tasks/xinetd.yml
+++ b/tasks/xinetd.yml
@@ -18,4 +18,4 @@
     owner: 'root'
     group: 'root'
     mode: '0644'
-  notify: [ Restart xinetd ]
+  notify: [ 'Restart xinetd' ]


### PR DESCRIPTION
- Tested/updated for ferm role and switched to `ferm_dependent_rules`.
- Defaults parameters should be separated by two empty lines according
  to drybjed.
- Use shorter when statements and don’t fail when local facts are not
  defined.
- Added tags for role dependencies.
- Keep description in sync with description on GitHub.
