### PR TITLE
Setup check plugin `mk_mysql` automatically.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -114,6 +114,63 @@ checkmk_agent_plugin_autodetect: True
 checkmk_agent_plugin_path: '/usr/lib/check_mk_agent/plugins'
 
 
+# .. envvar:: checkmk_agent_group_plugin_map
+#
+# DebOps hostgroup to plugin mapping.
+checkmk_agent_group_plugin_map:
+  debops_mariadb_server: 'mk_mysql'
+  debops_mysql: 'mk_mysql'
+  debops_nginx: 'nginx_status'
+  debops_postgresql: 'mk_postgres'
+
+
+# .. envvar:: checkmk_agent_plugin_list
+#
+# Combined list of all plugins which are going to be installed.
+# Plugins which can be detected by looking at the host group will be added
+# accruing to :ref:`checkmk_agent_group_plugin_map` when
+# :ref:`checkmk_agent_plugin_autodetect` is ``True``.
+checkmk_agent_plugin_list: '{{ (
+  (checkmk_agent_plugins|d([])) +
+  (checkmk_agent_group_plugins|d([])) +
+  (checkmk_agent_host_plugins|d([])) ) | unique }}'
+
+
+# -------------------------
+#   MySQL/MariaDB monitoring plugins options
+# -------------------------
+
+# .. envvar:: checkmk_agent_plugin_mysql
+#
+# When a host should get the ``mk_mysql`` monitoring plugin then additionally
+# automatically configure it. This will setup a database user which has read
+# access to the database server.
+# Set to ``manual`` to configure it manually.
+# See https://mathias-kettner.de/checkmk_mysql.html
+checkmk_agent_plugin_mysql: 'automatic'
+
+
+# .. envvar:: checkmk_agent_plugin_mysql_user
+#
+# Database user account name to use for monitoring.
+checkmk_agent_plugin_mysql_user: 'monitor'
+
+
+# .. envvar:: checkmk_agent_plugin_mysql_password
+#
+# Database user password to use for monitoring.
+checkmk_agent_plugin_mysql_password: "{{ lookup('password', secret + '/mariadb/' +
+                                         ansible_local.mariadb.delegate_to +
+                                         '/credentials/' + checkmk_agent_plugin_mysql_user +
+                                         '/password length=48') }}"
+
+
+# .. envvar:: checkmk_agent_plugin_mysql_priv
+#
+# Privilages of the database user used for monitoring.
+checkmk_agent_plugin_mysql_priv: '*.*:SELECT,SHOW DATABASES'
+
+
 # --------------------------------
 #   Agent plugins source options
 # --------------------------------

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -1,0 +1,33 @@
+
+Ansible tags
+------------
+
+You can use Ansible ``--tags`` or ``--skip-tags`` parameters to limit what
+tasks are performed during Ansible run. This can be used after host is first
+configured to speed up playbook execution, when you are sure that most of the
+configuration has not been changed.
+
+Available role tags:
+
+``role::checkmk_agent``
+  Main role tag, should be used in the playbook to execute all of the role
+  tasks as well as role dependencies.
+
+``type::dependency``
+  This tag specifies which tasks are defined in role dependencies. You can use
+  this to omit them using ``--skip-tags`` parameter.
+
+``depend-of::checkmk_agent``
+  Execute all ``debops.contrib-checkmk_agent`` role dependencies in its context.
+
+``depend::apt_preferences:checkmk_agent``
+  Run ``debops.apt_preferences`` dependent role in ``debops.contrib-checkmk_agent`` context.
+
+``depend::etc_services:checkmk_agent``
+  Run ``debops.etc_services`` dependent role in ``debops.contrib-checkmk_agent`` context.
+
+``depend::ferm:checkmk_agent``
+  Run ``debops.ferm`` dependent role in ``debops.contrib-checkmk_agent`` context.
+
+``role::checkmk_agent:plugins``
+  Run tasks related to Check_MK agent plugin configuration.

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -25,6 +25,21 @@ dependencies:
     ferm_dependent_rules: '{{ checkmk_agent_ferm_dependent_rules }}'
     when: (checkmk_agent|d() and 'xinetd' in checkmk_agent)
 
+  - role: debops.mariadb
+    mariadb_users:
+      - user: '{{ checkmk_agent_plugin_mysql_user }}'
+        password: '{{ checkmk_agent_plugin_mysql_password }}'
+        priv: '{{ checkmk_agent_plugin_mysql_priv }}'
+        priv_default: False
+        priv_aux: False
+        append_privs: False
+        owner: 'root'
+        creds_path: '/etc/check_mk/mysql.cfg'
+    when: (("mk_mysql" in checkmk_agent_plugin_list and checkmk_agent_plugin_mysql|d("automatic") == "automatic") or
+            ((checkmk_agent_plugin_autodetect|d(True) | bool) and "debops_mariadb_server" in hostvars[inventory_hostname]["group_names"])
+          )
+    tags: [ 'depend::mariadb', 'depend::mariadb:checkmk_agent',
+            'depend-of::checkmk_agent', 'type::dependency' ]
 
 galaxy_info:
   author: 'Reto Gantenbein'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -38,6 +38,7 @@
   when: (checkmk_agent|d() and 'xinetd' in checkmk_agent)
 
 - include: setup_plugins.yml
+  tags: [ 'role::checkmk_agent:plugins' ]
   when: (checkmk_agent|d() and
          ansible_local|d() and ansible_local.checkmk_agent|d() and
          ansible_local.checkmk_agent.checkmk_agent_plugin_list|d())

--- a/tasks/setup_plugins.yml
+++ b/tasks/setup_plugins.yml
@@ -17,7 +17,7 @@
   synchronize:
     src: '{{ checkmk_agent_git_dest }}/agents/plugins/{{ item }}'
     dest: '{{ checkmk_agent_plugin_path }}'
-    checksum: yes
-    mode: push
+    checksum: True
+    mode: 'push'
   with_items: ansible_local.checkmk_agent.checkmk_agent_plugin_list
   delegate_to: '{{ inventory_hostname }}'

--- a/templates/etc/ansible/facts.d/checkmk_agent.fact.j2
+++ b/templates/etc/ansible/facts.d/checkmk_agent.fact.j2
@@ -1,4 +1,4 @@
-{% set checkmk_agent_tpl_plugin_list = (checkmk_agent_plugins | union(checkmk_agent_group_plugins)) | union(checkmk_agent_host_plugins) | unique %}
+{% set checkmk_agent_tpl_plugin_list = checkmk_agent_plugin_list %}
 {% if checkmk_agent_plugin_autodetect is defined and checkmk_agent_plugin_autodetect %}
 {% for hostgroup in hostvars[inventory_hostname]['group_names'] | intersect(checkmk_agent_group_plugin_map.keys()) %}
 {% set _ = checkmk_agent_tpl_plugin_list.append(checkmk_agent_group_plugin_map[hostgroup]) %}

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,8 +1,0 @@
----
-
-# DebOps hostgroup to plugin mapping
-checkmk_agent_group_plugin_map:
-  debops_mariadb_server: 'mk_mysql'
-  debops_mysql: 'mk_mysql'
-  debops_nginx: 'nginx_status'
-  debops_postgresql: 'mk_postgres'


### PR DESCRIPTION
- This commit also moves the `checkmk_agent_group_plugin_map` to
  `defaults/main.yml` to make it easier to change for users.

Related to: https://github.com/debops/ansible-mariadb/pull/10

BTW: @drybjed would like to migrate the role to the DebOps project :wink: @ganto Can you maybe give me commit access?
