### PR TITLE
Make nginx_status plugin work with the default nginx config in DebOps.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -119,9 +119,13 @@ checkmk_agent_plugin_path: '/usr/lib/check_mk_agent/plugins'
 # DebOps hostgroup to plugin mapping.
 checkmk_agent_group_plugin_map:
   debops_mariadb_server: 'mk_mysql'
+  debops_service_mariadb_server: 'mk_mysql'
   debops_mysql: 'mk_mysql'
+  debops_service_mysql: 'mk_mysql'
   debops_nginx: 'nginx_status'
+  debops_service_nginx: 'nginx_status'
   debops_postgresql: 'mk_postgres'
+  debops_service_postgresql: 'mk_postgres'
 
 
 # .. envvar:: checkmk_agent_plugin_list

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -186,10 +186,23 @@ checkmk_agent_plugin_mysql_priv: '*.*:SELECT,SHOW DATABASES'
 # the plugin fails for example because the default server does not allow
 # ``/nginx_status``. This can happen because the plugin tires to connect with
 # the IP address set as Host.
-# This is currently enabled as workaround. See https://github.com/debops-contrib/ansible-checkmk_agent/pull/3
+# This is currently set manually to ``localhost`` as workaround. See
+# https://github.com/debops-contrib/ansible-checkmk_agent/pull/3
+#
 # .. _nginx_status: https://mathias-kettner.de/checkmk_check_nginx_status.html
-# checkmk_agent_plugin_nginx_servers: 'automatic'
-
+#
+# Example::
+#
+#   checkmk_agent_plugin_nginx_servers:
+#     - proto: 'http'
+#       ipaddress: 'some-appliance.corp.com'
+#       port: 80
+#     - proto: 'http'
+#       ipaddress: '[::1]'
+#       port: 80
+#
+#   checkmk_agent_plugin_nginx_servers: 'automatic'
+#
 checkmk_agent_plugin_nginx_servers:
   - proto: 'http'
     ipaddress: 'localhost'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -175,6 +175,27 @@ checkmk_agent_plugin_mysql_password: "{{ lookup('password', secret + '/mariadb/'
 checkmk_agent_plugin_mysql_priv: '*.*:SELECT,SHOW DATABASES'
 
 
+# -------------------------
+#   nginx monitoring plugins options
+# -------------------------
+
+# .. envvar:: checkmk_agent_plugin_nginx_servers
+#
+# This option allows you to configure the servers which nginx_status_
+# plugin should monitoring. This might be required when the auto detection of
+# the plugin fails for example because the default server does not allow
+# ``/nginx_status``. This can happen because the plugin tires to connect with
+# the IP address set as Host.
+# This is currently enabled as workaround. See https://github.com/debops-contrib/ansible-checkmk_agent/pull/3
+# .. _nginx_status: https://mathias-kettner.de/checkmk_check_nginx_status.html
+# checkmk_agent_plugin_nginx_servers: 'automatic'
+
+checkmk_agent_plugin_nginx_servers:
+  - proto: 'http'
+    ipaddress: 'localhost'
+    port: 80
+
+
 # --------------------------------
 #   Agent plugins source options
 # --------------------------------

--- a/tasks/setup_plugins.yml
+++ b/tasks/setup_plugins.yml
@@ -21,3 +21,18 @@
     mode: 'push'
   with_items: ansible_local.checkmk_agent.checkmk_agent_plugin_list
   delegate_to: '{{ inventory_hostname }}'
+
+- name: Configure nginx_status plugin
+  template:
+    src: 'etc/check_mk/nginx_status.cfg.j2'
+    dest: '/etc/check_mk/nginx_status.cfg'
+    owner: 'root'
+    group: 'root'
+    mode: '0644'
+  when: (checkmk_agent_plugin_nginx_servers is defined and checkmk_agent_plugin_nginx_servers is not string)
+
+- name: Ensure that nginx_status.cfg is absent for automatic detection
+  file:
+    path: '/etc/check_mk/nginx_status.cfg'
+    state: 'absent'
+  when: (checkmk_agent_plugin_nginx_servers|d("automatic") == "automatic")

--- a/templates/etc/ansible/facts.d/checkmk_agent.fact.j2
+++ b/templates/etc/ansible/facts.d/checkmk_agent.fact.j2
@@ -1,8 +1,8 @@
 {% set checkmk_agent_tpl_plugin_list = checkmk_agent_plugin_list %}
-{% if checkmk_agent_plugin_autodetect is defined and checkmk_agent_plugin_autodetect %}
-{% for hostgroup in hostvars[inventory_hostname]['group_names'] | intersect(checkmk_agent_group_plugin_map.keys()) %}
-{% set _ = checkmk_agent_tpl_plugin_list.append(checkmk_agent_group_plugin_map[hostgroup]) %}
-{% endfor %}
+{% if checkmk_agent_plugin_autodetect|d() %}
+{%   for hostgroup in hostvars[inventory_hostname]['group_names'] | intersect(checkmk_agent_group_plugin_map.keys()) %}
+{%     set _ = checkmk_agent_tpl_plugin_list.append(checkmk_agent_group_plugin_map[hostgroup]) %}
+{%   endfor %}
 {% endif %}
 {
 "checkmk_agent_plugin_list" : {{ checkmk_agent_tpl_plugin_list | to_nice_json }}

--- a/templates/etc/check_mk/nginx_status.cfg.j2
+++ b/templates/etc/check_mk/nginx_status.cfg.j2
@@ -1,3 +1,3 @@
 # {{ ansible_managed }}
 
-servers = [ {% for server in checkmk_agent_plugin_nginx_servers %}('{{ server.proto }}', '{{ server.ipaddress }}', {{ server.port }}){% endfor %} ]
+servers = [ {% for server in checkmk_agent_plugin_nginx_servers %}('{{ server.proto }}', '{{ server.ipaddress }}', {{ server.port }}){{ ', ' if (not loop.last) else '' }}{% endfor %} ]

--- a/templates/etc/check_mk/nginx_status.cfg.j2
+++ b/templates/etc/check_mk/nginx_status.cfg.j2
@@ -1,0 +1,3 @@
+# {{ ansible_managed }}
+
+servers = [ {% for server in checkmk_agent_plugin_nginx_servers %}('{{ server.proto }}', '{{ server.ipaddress }}', {{ server.port }}){% endfor %} ]


### PR DESCRIPTION
@ganto Or did I miss something? I setup nginx with `debops.nginx` defaults and this change was required. Another way would be to make the localhost nginx server also respond for its ip address set as `server_name`.
