### PR TITLE
Support to run the agent as nagios user.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,0 +1,9 @@
+Changelog
+=========
+
+v0.1.0
+------
+
+*Unreleased*
+
+- Add Changelog. [ypid]

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -57,6 +57,15 @@ checkmk_agent_ferm_dependent_rules:
 checkmk_agent_exec: '/usr/bin/check_mk_agent'
 
 
+# .. envvar:: checkmk_agent_exec_user
+#
+# System user under which the Check_MK agent is executed.
+# The Check_MK agent default is ``root`` which not best practice.
+# This role uses an unprivileged user by default which might need some adoption
+# for plugins.
+checkmk_agent_exec_user: 'nagios'
+
+
 # .. envvar:: checkmk_agent_port
 #
 # Listen port for Check_MK agent.
@@ -66,20 +75,20 @@ checkmk_agent_port: '6556'
 
 # .. Agent SSH user options (((
 #
-# --------------------------
-#   Agent SSH user options
-# --------------------------
+# -------------------------------------
+#   Agent SSH and system user options
+# -------------------------------------
 
-# .. envvar:: checkmk_agent_ssh_user
+# .. envvar:: checkmk_agent_system_user
 #
 # SSH user to query Check_MK agent.
-checkmk_agent_ssh_user: 'nagios'
+checkmk_agent_system_user: 'nagios'
 
 
-# .. envvar:: checkmk_agent_ssh_group
+# .. envvar:: checkmk_agent_system_group
 #
 # Primary group of SSH user querying Check_MK agent.
-checkmk_agent_ssh_group: 'nagios'
+checkmk_agent_system_group: 'nagios'
 
 
 # .. envvar:: checkmk_agent_user_home
@@ -150,12 +159,18 @@ checkmk_agent_group_plugin_map:
 #
 # Combined list of all plugins which are going to be installed.
 # Plugins which can be detected by looking at the host group will be added
-# accruing to :ref:`checkmk_agent_group_plugin_map` when
+# according to :ref:`checkmk_agent_group_plugin_map` when
 # :ref:`checkmk_agent_plugin_autodetect` is ``True``.
 checkmk_agent_plugin_list: '{{ (
   (checkmk_agent_plugins|d([])) +
   (checkmk_agent_group_plugins|d([])) +
-  (checkmk_agent_host_plugins|d([])) ) | unique }}'
+  (checkmk_agent_host_plugins|d([])) +
+  (
+    (hostvars[inventory_hostname]["group_names"] | intersect(checkmk_agent_group_plugin_map.keys()) | map("extract", checkmk_agent_group_plugin_map) | list)
+    if (checkmk_agent_plugin_autodetect | bool) else []
+  ) +
+  []
+  ) | unique }}'
 
 # .. )))
 
@@ -170,7 +185,7 @@ checkmk_agent_plugin_list: '{{ (
 # When a host should get the ``mk_mysql`` monitoring plugin then additionally
 # automatically configure it. This will setup a database user which has read
 # access to the database server.
-# Set to ``manual`` to configure it manually.
+# Set to ``manual`` when you prefer configure manually.
 # See https://mathias-kettner.de/checkmk_mysql.html
 checkmk_agent_plugin_mysql: 'automatic'
 
@@ -184,10 +199,10 @@ checkmk_agent_plugin_mysql_user: 'monitor'
 # .. envvar:: checkmk_agent_plugin_mysql_password
 #
 # Database user password to use for monitoring.
-checkmk_agent_plugin_mysql_password: "{{ lookup('password', secret + '/mariadb/' +
+checkmk_agent_plugin_mysql_password: '{{ lookup("password", secret + "/mariadb/" +
                                          ansible_local.mariadb.delegate_to +
-                                         '/credentials/' + checkmk_agent_plugin_mysql_user +
-                                         '/password length=48') }}"
+                                         "/credentials/" + checkmk_agent_plugin_mysql_user +
+                                         "/password length=48") }}'
 
 
 # .. envvar:: checkmk_agent_plugin_mysql_priv
@@ -205,7 +220,7 @@ checkmk_agent_plugin_mysql_priv: '*.*:SELECT,SHOW DATABASES'
 
 # .. envvar:: checkmk_agent_plugin_nginx_servers
 #
-# This option allows you to configure the servers which nginx_status_
+# This option allows you to configure the servers which the nginx_status_
 # plugin should monitoring. This might be required when the auto detection of
 # the plugin fails for example because the default server does not allow
 # ``/nginx_status``. This can happen because the plugin tires to connect with

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -159,8 +159,8 @@ checkmk_agent_group_plugin_map:
 #
 # Combined list of all plugins which are going to be installed.
 # Plugins which can be detected by looking at the host group will be added
-# according to :ref:`checkmk_agent_group_plugin_map` when
-# :ref:`checkmk_agent_plugin_autodetect` is ``True``.
+# according to ``checkmk_agent_group_plugin_map`` when
+# ``checkmk_agent_plugin_autodetect`` is ``True``.
 checkmk_agent_plugin_list: '{{ (
   (checkmk_agent_plugins|d([])) +
   (checkmk_agent_group_plugins|d([])) +
@@ -176,9 +176,9 @@ checkmk_agent_plugin_list: '{{ (
 
 # .. MySQL/MariaDB monitoring plugins options (((
 #
-# -------------------------
+# --------------------------------------------
 #   MySQL/MariaDB monitoring plugins options
-# -------------------------
+# --------------------------------------------
 
 # .. envvar:: checkmk_agent_plugin_mysql
 #

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,0 +1,1 @@
+.. include:: ../CHANGES.rst

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,7 +1,7 @@
-.. _debops.dovecot:
+.. _debops.contrib-checkmk_agent:
 
-Ansible role: debops.dovecot
-============================
+Ansible role: debops.contrib-checkmk_agent
+==========================================
 
 .. toctree::
    :maxdepth: 2
@@ -10,7 +10,6 @@ Ansible role: debops.dovecot
    installation
    getting-started
    defaults
-   guides
    copyright
    credits
    changelog

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -6,7 +6,7 @@ to your `DebOps`_ project roles directory::
 
     git clone https://github.com/debops-contrib/ansible-checkmk_agent.git
 
-:: _DebOps: http://debops.org/
+.. _DebOps: http://debops.org/
 
 Role dependencies
 ~~~~~~~~~~~~~~~~~

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -18,13 +18,13 @@ dependencies:
       - name: 'check-mk-agent'
         port: '{{ checkmk_agent_port }}'
         comment: 'Check_MK agent (via xinetd)'
-    when: (checkmk_agent|d() and 'xinetd' in checkmk_agent)
+    when: ("xinetd" in checkmk_agent|d([]))
 
   - role: debops.ferm
     tags: [ 'depend::ferm', 'depend::ferm:checkmk_agent',
             'depend-of::checkmk_agent', 'type::dependency' ]
     ferm_dependent_rules: '{{ checkmk_agent_ferm_dependent_rules }}'
-    when: (checkmk_agent|d() and 'xinetd' in checkmk_agent)
+    when: ("xinetd" in checkmk_agent|d([]))
 
   - role: debops.mariadb
     mariadb_users:
@@ -36,9 +36,7 @@ dependencies:
         append_privs: False
         owner: 'root'
         creds_path: '/etc/check_mk/mysql.cfg'
-    when: (("mk_mysql" in checkmk_agent_plugin_list and checkmk_agent_plugin_mysql|d("automatic") == "automatic") or
-            ((checkmk_agent_plugin_autodetect|d(True) | bool) and "debops_mariadb_server" in hostvars[inventory_hostname]["group_names"])
-          )
+    when: ("mk_mysql" in checkmk_agent_plugin_list and checkmk_agent_plugin_mysql == "automatic")
     tags: [ 'depend::mariadb', 'depend::mariadb:checkmk_agent',
             'depend-of::checkmk_agent', 'type::dependency' ]
 
@@ -48,7 +46,7 @@ galaxy_info:
   author: 'Reto Gantenbein, Robin Schneider'
   description: 'Setup Check_MK monitoring agent'
   license: 'GNU General Public License v3'
-  min_ansible_version: '1.7.0'
+  min_ansible_version: '2.1.0'
 
   platforms:
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -40,13 +40,19 @@
     group: 'root'
     mode: '0755'
 
-- include: ssh_user.yml
-  when: (checkmk_agent|d() and 'ssh' in checkmk_agent)
+- name: Run tasks related to system user configuration
+  include: system_user.yml
 
-- include: xinetd.yml
-  when: (checkmk_agent|d() and 'xinetd' in checkmk_agent)
+- name: Run tasks related to ssh user configuration
+  include: ssh_user.yml
+  when: ("ssh" in checkmk_agent|d([]))
 
-- include: setup_plugins.yml
+- name: Run tasks related to xinetd configuration
+  include: xinetd.yml
+  when: ("xinetd" in checkmk_agent|d([]))
+
+- name: Run tasks related to plugin setup
+  include: setup_plugins.yml
   tags: [ 'role::checkmk_agent:plugins' ]
   when: (checkmk_agent|d() and
          ansible_local|d() and ansible_local.checkmk_agent|d() and

--- a/tasks/setup_plugins.yml
+++ b/tasks/setup_plugins.yml
@@ -1,5 +1,45 @@
 ---
 
+# Configure plugins before installing them to prevent unconfigured plugins from running.
+
+# .. Plugin: nginx_status  (((
+- name: Configure nginx_status plugin
+  template:
+    src: 'etc/check_mk/nginx_status.cfg.j2'
+    dest: '/etc/check_mk/nginx_status.cfg'
+    owner: 'root'
+    group: '{{ checkmk_agent_system_group }}'
+    mode: '0644'
+  when: ("nginx_status" in checkmk_agent_plugin_list and
+         checkmk_agent_plugin_nginx_servers is defined and checkmk_agent_plugin_nginx_servers is not string)
+
+- name: Ensure that nginx_status.cfg is absent for automatic detection
+  file:
+    path: '/etc/check_mk/nginx_status.cfg'
+    state: 'absent'
+  when: (checkmk_agent_plugin_nginx_servers|d("automatic") == "automatic")
+# .. )))
+
+# .. Plugin: mk_mysql  (((
+- name: Configure mk_mysql plugin
+  template:
+    src: 'etc/check_mk/mysql.cfg.j2'
+    dest: '/etc/check_mk/mysql.cfg'
+    owner: 'root'
+    group: '{{ checkmk_agent_system_group }}'
+    mode: '0640'
+  when: ("mk_mysql" in checkmk_agent_plugin_list and checkmk_agent_plugin_mysql == "automatic")
+
+- name: Ensure that mysql.cfg is absent when the plugin is not enabled
+  file:
+    path: '/etc/check_mk/mysql.cfg'
+    state: 'absent'
+  when: ("mk_mysql" not in checkmk_agent_plugin_list)
+
+# .. )))
+
+# .. Install plugins (((
+
 - name: Get Check_MK agent version
   shell: dpkg-query -W -f='${Version}\n' check-mk-agent 2>/dev/null | sed -e 's/^.*://' || true
   register: checkmk_agent_register_package_dpkg_version
@@ -22,17 +62,4 @@
   with_items: '{{ ansible_local.checkmk_agent.checkmk_agent_plugin_list }}'
   delegate_to: '{{ inventory_hostname }}'
 
-- name: Configure nginx_status plugin
-  template:
-    src: 'etc/check_mk/nginx_status.cfg.j2'
-    dest: '/etc/check_mk/nginx_status.cfg'
-    owner: 'root'
-    group: 'root'
-    mode: '0644'
-  when: (checkmk_agent_plugin_nginx_servers is defined and checkmk_agent_plugin_nginx_servers is not string)
-
-- name: Ensure that nginx_status.cfg is absent for automatic detection
-  file:
-    path: '/etc/check_mk/nginx_status.cfg'
-    state: 'absent'
-  when: (checkmk_agent_plugin_nginx_servers|d("automatic") == "automatic")
+# .. )))

--- a/tasks/ssh_user.yml
+++ b/tasks/ssh_user.yml
@@ -1,20 +1,5 @@
 ---
 
-- name: Create Check_MK SSH user group
-  group:
-    name: '{{ checkmk_agent_ssh_group }}'
-    system: 'yes'
-
-- name: Create Check_MK SSH user
-  user:
-    name: '{{ checkmk_agent_ssh_user }}'
-    group: '{{ checkmk_agent_ssh_group }}'
-    groups: 'sshusers'
-    system: 'yes'
-    shell: '/bin/sh'
-    home: '{{ checkmk_agent_user_home }}'
-    createhome: 'yes'
-
 - name: Create SSH authorized_keys directory
   file:
     name: '/etc/ssh/authorized_keys'
@@ -26,7 +11,7 @@
 - name: Set SSH key for public key login
   template:
     src: '{{ lookup("template_src", "etc/ssh/authorized_keys/nagios.j2") }}'
-    dest: '/etc/ssh/authorized_keys/{{ checkmk_agent_ssh_user }}'
+    dest: '/etc/ssh/authorized_keys/{{ checkmk_agent_system_user }}'
     owner: 'root'
     group: 'root'
     mode: '644'

--- a/tasks/system_user.yml
+++ b/tasks/system_user.yml
@@ -1,0 +1,16 @@
+---
+
+- name: Create Check_MK system user group
+  group:
+    name: '{{ checkmk_agent_system_group }}'
+    system: 'yes'
+
+- name: Create Check_MK system user
+  user:
+    name: '{{ checkmk_agent_system_user }}'
+    group: '{{ checkmk_agent_system_group }}'
+    groups: '{{ "sshusers" if ("ssh" in checkmk_agent|d([])) else "" }}'
+    system: 'yes'
+    shell: '/bin/sh'
+    home: '{{ checkmk_agent_user_home }}'
+    createhome: 'yes'

--- a/templates/etc/ansible/facts.d/checkmk_agent.fact.j2
+++ b/templates/etc/ansible/facts.d/checkmk_agent.fact.j2
@@ -1,9 +1,3 @@
-{% set checkmk_agent_tpl_plugin_list = checkmk_agent_plugin_list %}
-{% if checkmk_agent_plugin_autodetect|d() %}
-{%   for hostgroup in hostvars[inventory_hostname]['group_names'] | intersect(checkmk_agent_group_plugin_map.keys()) %}
-{%     set _ = checkmk_agent_tpl_plugin_list.append(checkmk_agent_group_plugin_map[hostgroup]) %}
-{%   endfor %}
-{% endif %}
 {
-"checkmk_agent_plugin_list" : {{ checkmk_agent_tpl_plugin_list | to_nice_json }}
+"checkmk_agent_plugin_list" : {{ checkmk_agent_plugin_list | to_nice_json }}
 }

--- a/templates/etc/check_mk/mysql.cfg.j2
+++ b/templates/etc/check_mk/mysql.cfg.j2
@@ -1,0 +1,5 @@
+# {{ ansible_managed }}
+
+[client]
+user={{ checkmk_agent_plugin_mysql_user }}
+password={{ checkmk_agent_plugin_mysql_password }}

--- a/templates/etc/sudoers.d/check-mk-agent.j2
+++ b/templates/etc/sudoers.d/check-mk-agent.j2
@@ -1,4 +1,4 @@
 # {{ ansible_managed }}
 
-Defaults: {{ checkmk_agent_ssh_user }} !requiretty
-{{ checkmk_agent_ssh_user }} ALL=(root) NOPASSWD: {{ checkmk_agent_exec }}
+Defaults: {{ checkmk_agent_system_user }} !requiretty
+{{ checkmk_agent_system_user }} ALL=(root) NOPASSWD: {{ checkmk_agent_exec }}

--- a/templates/etc/xinetd.d/check_mk.j2
+++ b/templates/etc/xinetd.d/check_mk.j2
@@ -7,7 +7,7 @@ service check_mk
     socket_type    = stream
     protocol       = tcp
     wait           = no
-    user           = root
+    user           = {{ checkmk_agent_exec_user }}
     server         = {{ checkmk_agent_exec }}
 
 {#  # If you use fully redundant monitoring and poll the client


### PR DESCRIPTION
Related to #5.
- Requiring Ansible 2.1.0 because of the reworked `checkmk_agent_plugin_list` gathering using the [`map('extract', ...)` filter feature](https://docs.ansible.com/ansible/playbooks_filters.html#extracting-values-from-containers).

This PR is currently a preview as it requires Ansible 2.1. I will rebase
and review this PR again once Ansible 2.1 has been released. Until then,
I will test running the agent under the nagios user using xinetd.
