### PR TITLE
Register agent via WebAPI on Check_MK server

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ This role requires at least Ansible `v1.9`. To install it, run:
 ansible-galaxy install debops-contrib.checkmk_agent
 ```
 
+### Role dependencies
+
+- `debops.secret`
+
 ### Are you using this as a standalone role without DebOps?
 
 You may need to include missing roles from the [DebOps common

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -87,6 +87,55 @@ checkmk_agent__site: '{{ hostvars[checkmk_agent__server].ansible_local.checkmk_s
                              ("checkmk_server" in hostvars[checkmk_agent__server].ansible_local))
                          else "debops" }}'
 
+
+# .. envvar:: checkmk_agent__autojoin
+#
+# Automatically add agent host to the Check_MK monitoring site.
+checkmk_agent__autojoin: '{{ True if checkmk_agent__autojoin_url else False }}'
+
+
+# .. envvar:: checkmk_agent__autojoin_url
+#
+# Check_MK server WebAPI URL for agent registration. By default it will be
+# autodetected from the local facts stored under the `checkmk_server`
+# dictionary key. If the Check_MK server is managed manually this variable
+# must be defined accordingly in the Ansible inventory.
+checkmk_agent__autojoin_url: '{{ hostvars[checkmk_agent__server].ansible_local.checkmk_server[checkmk_agent__site].webapi_url|d("")
+                                if (checkmk_agent__server|d() and
+                                    (checkmk_agent__server in hostvars) and
+                                    ("ansible_local" in hostvars[checkmk_agent__server]) and
+                                    ("checkmk_server" in hostvars[checkmk_agent__server].ansible_local) and
+                                    (checkmk_agent__site in hostvars[checkmk_agent__server].ansible_local.checkmk_server))
+                                else "" }}'
+
+
+# .. envvar:: checkmk_agent__autojoin_user
+#
+# Account for agent registration via Check_MK WebAPI.
+checkmk_agent__autojoin_user: 'ansible'
+
+
+# .. envvar:: checkmk_agent__autojoin_secret
+#
+# Authentication secret for WebAPI registration. If the Check_MK server is
+# managed manually the password path must be adjusted accordingly in the
+# Ansible inventory.
+checkmk_agent__autojoin_secret: '{{ lookup("password", secret + "/credentials/" + hostvars[checkmk_agent__server].ansible_fqdn + "/checkmk_server/" + checkmk_agent__site + "/" + checkmk_agent__autojoin_user + "/secret")|d("")
+                                    if checkmk_agent__server|d() and checkmk_agent__site|d() else "" }}'
+
+
+# .. envvar:: checkmk_agent__hostname
+#
+# Hostname of the agent host used for registration.
+checkmk_agent__hostname: '{{ ansible_fqdn }}'
+
+
+# .. envvar:: checkmk_agent__host_attributes
+#
+# Check_MK attributes and WATO tags used for managing the host.
+checkmk_agent__host_attributes:
+  tag_agent: '{{ "cmk-agent-ssh" if "ssh" in checkmk_agent else "cmk-agent" }}'
+
 # .. )))
 
 # .. Agent xinetd options (((

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -132,7 +132,8 @@ checkmk_agent__hostname: '{{ ansible_fqdn }}'
 
 # .. envvar:: checkmk_agent__host_attributes
 #
-# Check_MK attributes and WATO tags used for managing the host.
+# Check_MK attributes and WATO tags used for managing the host. For more
+# details check :ref:`checkmk_agent__host_attributes`.
 checkmk_agent__host_attributes:
   tag_agent: '{{ "cmk-agent-ssh" if "ssh" in checkmk_agent else "cmk-agent" }}'
 

--- a/docs/defaults-configuration.rst
+++ b/docs/defaults-configuration.rst
@@ -1,0 +1,56 @@
+Default variables: configuration
+================================
+
+Some of the ``debops-contrib.checkmk_agent`` default variables have more
+extensive configuration values than simple strings or lists, here you can
+find documentation and examples for them.
+
+.. contents::
+   :local:
+      :depth: 1
+
+.. _checkmk_agent__host_attributes:
+
+checkmk_agent__host_attributes
+------------------------------
+
+This is a configuration dictionary defining the host attributes which are
+associated with this host in the Check_MK server Web interface (aka WATO).
+The following configuration keys are supported:
+
+``alias``
+  Optional. A comment or description of this host.
+
+``contactgroups``
+  Optional. Only members of the contact groups listed here have WATO
+  permission to this host. The value for this configuration key is another
+  dictionary where the following configuration keys must be defined:
+
+  ``groups``
+    Required. List of contact groups defined in WATO.
+
+  ``use_for_services``
+    Optional. With this option contact groups that are added to hosts are
+    always being added to services, as well. This only makes a difference
+    if you have assigned other contact groups to services via rules in
+    *Host & Service Parameters*. Allowed values are ``True`` and ``False``.
+    Defaults to ``False``.
+
+``ipaddress``
+  Optional. In case the name of the host is not resolvable via
+  :file:`/etc/hosts` or DNS by your monitoring server, you can specify an
+  explicit IP address or a resolvable DNS name of the host here.
+
+``parents``
+  Optional. List of host names which act as parents. Parents are used to
+  configure the reachability of hosts by the monitoring server. A host is
+  considered to be unreachable if all of its parents are unreachable or down.
+
+``site``
+  Optional. Name of the monitoring site that should monitor this host.
+
+``tag_<wato_tag>``
+  Optional. Any tag defined in the WATO Web interface or when using the server
+  role via ``checkmk_server__multisite_cfg_wato_host_tags`` can be assigned
+  here. Example: To set the WATO tag ``criticality`` to ``test`` this would be
+  defined as ``tag_criticality: test``.

--- a/docs/defaults-configuration.rst
+++ b/docs/defaults-configuration.rst
@@ -7,7 +7,7 @@ find documentation and examples for them.
 
 .. contents::
    :local:
-      :depth: 1
+   :depth: 1
 
 .. _checkmk_agent__host_attributes:
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,7 +9,7 @@ Ansible role: debops-contrib.checkmk_agent
    introduction
    getting-started
    defaults
-   defaults_configuration
+   defaults-configuration
    copyright
    changelog
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,6 +9,7 @@ Ansible role: debops-contrib.checkmk_agent
    introduction
    getting-started
    defaults
+   defaults_configuration
    copyright
    changelog
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,6 +1,9 @@
 ---
 
-dependencies: []
+dependencies:
+
+  - role: debops.secret
+
 
 galaxy_info:
 

--- a/tasks/autojoin.yml
+++ b/tasks/autojoin.yml
@@ -1,5 +1,12 @@
 ---
 
+- name: Set host attribute fact
+  set_fact:
+    checkmk_agent__fact_host_attributes: '{{ checkmk_agent__default_host_attributes |
+                                             combine(checkmk_agent__host_attributes, recursive=True)
+                                             if "contactgroups" in checkmk_agent__host_attributes
+                                             else checkmk_agent__host_attributes }}'
+
 - name: Query host on Check_MK site
   uri:
     url: '{{ checkmk_agent__autojoin_url }}?action=get_host&_username={{ checkmk_agent__autojoin_user }}&_secret={{ checkmk_agent__autojoin_secret }}&output_format=json'
@@ -16,7 +23,7 @@
   uri:
     url: '{{ checkmk_agent__autojoin_url }}?action=add_host&_do_confirm=yes&_username={{ checkmk_agent__autojoin_user }}&_secret={{ checkmk_agent__autojoin_secret }}&output_format=json'
     method: 'POST'
-    body: 'request={ "hostname": "{{ checkmk_agent__hostname }}", "folder": "/", "attributes": {{ checkmk_agent__host_attributes|to_json }} }'
+    body: 'request={ "hostname": "{{ checkmk_agent__hostname }}", "folder": "/", "attributes": {{ checkmk_agent__fact_host_attributes|to_json }} }'
     return_content: yes
     validate_certs: no
   when: '{{ checkmk_agent__register_get_host.json.result == "No such host" }}'
@@ -30,7 +37,7 @@
   uri:
     url: '{{ checkmk_agent__autojoin_url }}?action=edit_host&_username={{ checkmk_agent__autojoin_user }}&_secret={{ checkmk_agent__autojoin_secret }}&output_format=json'
     method: 'POST'
-    body: 'request={ "hostname": "{{ checkmk_agent__hostname }}", "attributes": {{ checkmk_agent__host_attributes|to_json }} }'
+    body: 'request={ "hostname": "{{ checkmk_agent__hostname }}", "attributes": {{ checkmk_agent__fact_host_attributes|to_json }} }'
     return_content: yes
     validate_certs: no
   when: '{{ checkmk_agent__register_add_host.skipped|d(False) and

--- a/tasks/autojoin.yml
+++ b/tasks/autojoin.yml
@@ -41,7 +41,7 @@
     return_content: yes
     validate_certs: no
   when: '{{ checkmk_agent__register_add_host.skipped|d(False) and
-           (not checkmk_agent__host_attributes|to_json == checkmk_agent__register_get_host.json.result.attributes|d({})|to_json) }}'
+           (not checkmk_agent__host_attributes|to_nice_json == checkmk_agent__register_get_host.json.result.attributes|d({})|to_nice_json) }}'
   register: checkmk_agent__register_update_host
   changed_when: ("json" in checkmk_agent__register_update_host) and
                 (checkmk_agent__register_update_host.json.result_code == 0)

--- a/tasks/autojoin.yml
+++ b/tasks/autojoin.yml
@@ -1,0 +1,55 @@
+---
+
+- name: Query host on Check_MK site
+  uri:
+    url: '{{ checkmk_agent__autojoin_url }}?action=get_host&_username={{ checkmk_agent__autojoin_user }}&_secret={{ checkmk_agent__autojoin_secret }}&output_format=json'
+    method: 'POST'
+    body: 'request={ "hostname": "{{ checkmk_agent__hostname }}" }'
+    return_content: yes
+    validate_certs: no
+  register: checkmk_agent__register_get_host
+  always_run: True
+  changed_when: False
+  failed_when: (not "json" in checkmk_agent__register_get_host)
+
+- name: Add host to Check_MK site via WebAPI
+  uri:
+    url: '{{ checkmk_agent__autojoin_url }}?action=add_host&_do_confirm=yes&_username={{ checkmk_agent__autojoin_user }}&_secret={{ checkmk_agent__autojoin_secret }}&output_format=json'
+    method: 'POST'
+    body: 'request={ "hostname": "{{ checkmk_agent__hostname }}", "folder": "/", "attributes": {{ checkmk_agent__host_attributes|to_json }} }'
+    return_content: yes
+    validate_certs: no
+  when: '{{ checkmk_agent__register_get_host.json.result == "No such host" }}'
+  register: checkmk_agent__register_add_host
+  changed_when: ("json" in checkmk_agent__register_add_host) and
+                (checkmk_agent__register_add_host.json.result_code == 0)
+  failed_when: (not "json" in checkmk_agent__register_add_host) or
+               (checkmk_agent__register_add_host.json.result_code != 0)
+
+- name: Update host attributes via WebAPI
+  uri:
+    url: '{{ checkmk_agent__autojoin_url }}?action=edit_host&_username={{ checkmk_agent__autojoin_user }}&_secret={{ checkmk_agent__autojoin_secret }}&output_format=json'
+    method: 'POST'
+    body: 'request={ "hostname": "{{ checkmk_agent__hostname }}", "attributes": {{ checkmk_agent__host_attributes|to_json }} }'
+    return_content: yes
+    validate_certs: no
+  when: '{{ checkmk_agent__register_add_host.skipped|d(False) and
+           (not checkmk_agent__host_attributes|to_json == checkmk_agent__register_get_host.json.result.attributes|d({})|to_json) }}'
+  register: checkmk_agent__register_update_host
+  changed_when: ("json" in checkmk_agent__register_update_host) and
+                (checkmk_agent__register_update_host.json.result_code == 0)
+  failed_when: (not "json" in checkmk_agent__register_update_host) or
+               (checkmk_agent__register_update_host.json.result_code != 0)
+
+- name: Activate WebAPI changes
+  uri:
+    url: '{{ checkmk_agent__autojoin_url }}?action=activate_changes&_username={{ checkmk_agent__autojoin_user }}&_secret={{ checkmk_agent__autojoin_secret }}&output_format=json'
+    return_content: yes
+    validate_certs: no
+  when: '{{ checkmk_agent__register_add_host.changed|d(False) or
+            checkmk_agent__register_update_host.changed|d(False) }}'
+  register: checkmk_agent__register_activate
+  changed_when: ("json" in checkmk_agent__register_activate) and
+                (checkmk_agent__register_activate.json.result_code == 0)
+  failed_when: (not "json" in checkmk_agent__register_activate) or
+               (checkmk_agent__register_activate.json.result_code != 0)

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -53,5 +53,10 @@
          ansible_local|d() and ansible_local.checkmk_agent|d() and
          ansible_local.checkmk_agent.checkmk_agent__plugin_list|d())
 
+- include: autojoin.yml
+  tags: [ 'role::checkmk_agent:autojoin' ]
+  when: (checkmk_agent|d() and
+         checkmk_agent__autojoin|d())
+
 - name: DebOps post_tasks hook
   include: "{{ lookup('task_src', 'checkmk_agent/post_main.yml') }}"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,0 +1,11 @@
+---
+
+# Default WATO host attributes. This variable, when being merged with
+# `checkmk_agent__host_attributes`, allows to successfully compare the WebAPI
+# get_host() response in case the `contactgroups` key is set.
+checkmk_agent__default_host_attributes:
+  contactgroups:
+    recurse_perms: False
+    recurse_use: False
+    use: True
+    use_for_services: False


### PR DESCRIPTION
The agent integration with the `debops-contrib/checkmk_server` role (see #14) is progressing. This PR will add an auto-registration feature to the agent role. It still needs some smaller adjustments to the default config, but soon it will be possible to setup (and adjust) monitoring of hosts in a fully automated manner.
