### PR TITLE
Add service discovery trigger via WebAPI

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -137,6 +137,15 @@ checkmk_agent__hostname: '{{ ansible_fqdn }}'
 checkmk_agent__host_attributes:
   tag_agent: '{{ "cmk-agent-ssh" if "ssh" in checkmk_agent else "cmk-agent" }}'
 
+
+# .. envvar:: checkmk_agent__discovery_mode
+#
+# Service discovery mode. Possible values are ``new`` (only find new services),
+# ``remove`` (remove exceeding services), ``fixall`` (remove exceeding and add
+# new services), ``refresh`` (clean all autochecks and discover from scratch)
+# and ``False`` (don't run service discovery).
+checkmk_agent__discovery_mode: 'new'
+
 # .. )))
 
 # .. Agent xinetd options (((

--- a/tasks/autojoin.yml
+++ b/tasks/autojoin.yml
@@ -45,12 +45,28 @@
   failed_when: (not "json" in checkmk_agent__register_update_host) or
                (checkmk_agent__register_update_host.json.result_code != 0)
 
+- name: Run service discovery
+  uri:
+    url: '{{ checkmk_agent__autojoin_url }}?action=discover_services&mode={{ checkmk_agent__discovery_mode }}&_username={{ checkmk_agent__autojoin_user }}&_secret={{ checkmk_agent__autojoin_secret }}&output_format=json'
+    method: 'POST'
+    body: 'request={ "hostname": "{{ checkmk_agent__hostname }}" }'
+    return_content: yes
+  when: '{{ checkmk_agent__discovery_mode|d() in [ "new", "remove", "fixall", "refresh" ] }}'
+  register: checkmk_agent__register_discover_services
+  changed_when: ("json" in checkmk_agent__register_discover_services) and
+                (checkmk_agent__register_discover_services.json.result_code == 0) and
+                ((checkmk_agent__register_discover_services.json.result | regex_replace("^.*Added ([0-9]+),.*$", "\\1")|int > 0) or
+                 (checkmk_agent__register_discover_services.json.result | regex_replace("^.*Removed ([0-9]+),.*$", "\\1")|int > 0))
+  failed_when: (not "json" in checkmk_agent__register_discover_services) or
+               (checkmk_agent__register_discover_services.json.result_code != 0)
+
 - name: Activate WebAPI changes
   uri:
     url: '{{ checkmk_agent__autojoin_url }}?action=activate_changes&_username={{ checkmk_agent__autojoin_user }}&_secret={{ checkmk_agent__autojoin_secret }}&output_format=json'
     return_content: yes
   when: '{{ checkmk_agent__register_add_host.changed|d(False) or
-            checkmk_agent__register_update_host.changed|d(False) }}'
+            checkmk_agent__register_update_host.changed|d(False) or
+            checkmk_agent__register_discover_services.changed|d(False) }}'
   register: checkmk_agent__register_activate
   changed_when: ("json" in checkmk_agent__register_activate) and
                 (checkmk_agent__register_activate.json.result_code == 0)


### PR DESCRIPTION
After a host has been added to Check_MK server trigger a service discovery via WebAPI. For more Information check the upstream documentation about [services](https://mathias-kettner.com/cms_wato_services.html).
