### PR TITLE
Rename SSH user and change default to SSH-based agent

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -223,6 +223,7 @@ checkmk_agent__user_key: '{{ hostvars[checkmk_agent__server].ansible_local.check
 # Authorized key configuration for the ``debops.authorized_keys`` role.
 checkmk_agent__authorized_keys__dependent_list:
   - name: '{{ checkmk_agent__ssh_user }}'
+    group: '{{ checkmk_agent__ssh_group }}'
     sshkeys:
       - '{{ checkmk_agent__user_key }}'
     options: '{{ authorized_keys__options_map.strict }}'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -197,6 +197,18 @@ checkmk_agent__ssh_user: 'checkmk'
 checkmk_agent__ssh_group: 'checkmk'
 
 
+# .. envvar:: checkmk_agent__ssh_allow_group
+#
+# Group membership required to access the system by SSH. If the ``AllowGroups``
+# :file:`sshd_config` option is not managed by ``debops.sshd`` this variable
+# might need to be defined accordingly in the Ansible inventory.
+checkmk_agent__ssh_allow_group: '{{ "sshusers"
+                                    if ("sshd" in ansible_local) and
+                                       ("allow_groups" in ansible_local.sshd) and
+                                       ("sshusers" in ansible_local.sshd.allow_groups)
+                                    else "" }}'
+
+
 # .. envvar:: checkmk_agent__user_home
 #
 # Home directory of SSH user querying Check_MK agent.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -188,19 +188,19 @@ checkmk_agent__etc_services__dependent_list:
 # .. envvar:: checkmk_agent__ssh_user
 #
 # SSH user to query Check_MK agent.
-checkmk_agent__ssh_user: 'nagios'
+checkmk_agent__ssh_user: 'checkmk'
 
 
 # .. envvar:: checkmk_agent__ssh_group
 #
 # Primary group of SSH user querying Check_MK agent.
-checkmk_agent__ssh_group: 'nagios'
+checkmk_agent__ssh_group: 'checkmk'
 
 
 # .. envvar:: checkmk_agent__user_home
 #
 # Home directory of SSH user querying Check_MK agent.
-checkmk_agent__user_home: '/var/lib/nagios'
+checkmk_agent__user_home: '/var/lib/check_mk_agent'
 
 
 # .. envvar:: checkmk_agent__user_key

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -29,11 +29,11 @@ checkmk_agent__apt_preferences__dependent_list:
     by_role: 'debops-contrib.checkmk_agent'
 
 
-# .. envvar:: checkmk_agent
+# .. envvar:: checkmk_agent__type
 #
-# Check_MK agent query protocol. Set to ``False`` to disable agent setup.
-# Valid options are ``ssh`` and ``xinetd``.
-checkmk_agent: [ 'xinetd' ]
+# List of Check_MK agent query protocols. Valid options are ``ssh`` and
+# ``xinetd``.
+checkmk_agent__type: [ 'ssh' ]
 
 
 # .. envvar:: checkmk_agent__allow

--- a/docs/playbooks/checkmk_agent.yml
+++ b/docs/playbooks/checkmk_agent.yml
@@ -16,21 +16,21 @@
               'depend-of::checkmk_agent', 'type::dependency' ]
       etc_services__dependent_list:
         - '{{ checkmk_agent__etc_services__dependent_list }}'
-      when: (checkmk_agent|d() and 'xinetd' in checkmk_agent)
+      when: ('xinetd' in checkmk_agent__type|d(['ssh']))
 
     - role: debops.ferm
       tags: [ 'depend::ferm', 'depend::ferm:checkmk_agent',
               'depend-of::checkmk_agent', 'type::dependency' ]
       ferm__dependent_rules:
         - '{{ checkmk_agent__ferm__dependent_rules }}'
-      when: (checkmk_agent|d() and 'xinetd' in checkmk_agent)
+      when: ('xinetd' in checkmk_agent__type|d(['ssh']))
 
     - role: debops.authorized_keys
       tags: [ 'depend::authorized_keys', 'depend::authorized_keys:checkmk_agent',
               'depend-of::checkmk_agent', 'type::dependency' ]
       authorized_keys__dependent_list:
         - '{{ checkmk_agent__authorized_keys__dependent_list }}'
-      when: (checkmk_agent|d() and 'ssh' in checkmk_agent)
+      when: ('ssh' in checkmk_agent__type|d(['ssh']))
 
     - role: debops.mariadb
       tags: [ 'depend::mariadb', 'depend::mariadb:checkmk_agent',

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -29,7 +29,6 @@
     name: '{{ item }}'
     state: 'present'
     install_recommends: False
-  when: checkmk_agent|d()
   with_items: '{{ checkmk_agent__base_packages }}'
 
 - name: Ensure the /etc/check_mk directory does exist
@@ -41,22 +40,20 @@
     mode: '0755'
 
 - include: ssh_user.yml
-  when: ((checkmk_agent|d() and 'ssh' in checkmk_agent) and
-         (not checkmk_agent__ssh_user == "root"))
+  when: ('ssh' in checkmk_agent__type|d(['ssh'])) and
+        (not checkmk_agent__ssh_user == "root")
 
 - include: xinetd.yml
-  when: (checkmk_agent|d() and 'xinetd' in checkmk_agent)
+  when: ('xinetd' in checkmk_agent__type|d(['ssh']))
 
 - include: setup_plugins.yml
   tags: [ 'role::checkmk_agent:plugins' ]
-  when: (checkmk_agent|d() and
-         ansible_local|d() and ansible_local.checkmk_agent|d() and
+  when: (ansible_local|d() and ansible_local.checkmk_agent|d() and
          ansible_local.checkmk_agent.checkmk_agent__plugin_list|d())
 
 - include: autojoin.yml
   tags: [ 'role::checkmk_agent:autojoin' ]
-  when: (checkmk_agent|d() and
-         checkmk_agent__autojoin|d())
+  when: (checkmk_agent__autojoin|d())
 
 - name: DebOps post_tasks hook
   include: "{{ lookup('task_src', 'checkmk_agent/post_main.yml') }}"

--- a/tasks/ssh_user.yml
+++ b/tasks/ssh_user.yml
@@ -21,4 +21,4 @@
     dest: '/etc/sudoers.d/check-mk-agent'
     owner: 'root'
     group: 'root'
-    mode: '0644'
+    mode: '0440'

--- a/tasks/ssh_user.yml
+++ b/tasks/ssh_user.yml
@@ -9,7 +9,7 @@
   user:
     name: '{{ checkmk_agent__ssh_user }}'
     group: '{{ checkmk_agent__ssh_group }}'
-    groups: 'sshusers'
+    groups: '{{ checkmk_agent__ssh_allow_group|d(omit) }}'
     system: 'yes'
     shell: '/bin/sh'
     home: '{{ checkmk_agent__user_home }}'


### PR DESCRIPTION
The user name `nagios` was originally chose, because at the very beginning I used the `check_mk` agent just as another active check, run via `check_by_ssh` in a Check_MK-enhanced Icinga setup. In the mean time most active checks could be replaced by agent plugins and now there is a fully integrated [checkmk_server](https://github.com/debops-contrib/ansible-checkmk_server) role which will generate an agent access configuration via SSH by default. Somehow the name `nagios` doesn't fit in this context anymore.

Also change the default agent setup from `xinetd`-based to SSH-based.

The old behaviour can be restored by setting the following configuration values:

```
checkmk_agent__type: [ 'xinetd' ]
checkmk_agent__ssh_user: nagios
checkmk_agent__ssh_group: nagios
checkmk_agent__user_home: /var/lib/nagios
```
