### PR TITLE
Fix lookup of non-default site from checkmk_server

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -78,7 +78,7 @@ checkmk_agent__server: '{{ groups["debops_service_checkmk_server"][0]
 # undefined or the Ansible local facts for `checkmk_agent__server` can't be
 # found. If the Check_MK server is managed manually this variable must be
 # defined accordingly in the Ansible inventory.
-checkmk_agent__site: '{{ hostvars[checkmk_agent__server].ansible_local.checkmk_server[0]|d("debops")
+checkmk_agent__site: '{{ hostvars[checkmk_agent__server].ansible_local.checkmk_server.keys()[0]|d("debops")
                          if (checkmk_agent__server|d() and
                              (checkmk_agent__server in hostvars) and
                              ("ansible_local" in hostvars[checkmk_agent__server]) and


### PR DESCRIPTION
When the `checkmk_server` role has created a non-default site which
was not explicitly specified by the agent via `checkmk_agent__site`,
the setup failed in the `debops.authorized_keys` role dependency, as
an empty key was passed to the role.