### PR TITLE
Various improvements regarding agent registration

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,28 @@ The current role maintainer_ is ganto_.
 
 .. _debops-contrib.checkmk_agent master: https://github.com/debops-contrib/ansible-checkmk_agent/compare/v0.1.1...master
 
+Added
+~~~~~
+
+- New inventory variable :envvar:`checkmk_agent__server_inventory_group` which
+  can be used to define custom Ansible host group name for Check_MK server
+  lookup. [ganto_]
+
+Changed
+~~~~~~~
+
+- Raise HTTP timeout for discovery and activation WebAPI calls to 120s to avoid
+  timeout issues on large hosts with many service checks. [ganto_]
+
+- If possible run WebAPI invocation for automated agent registration and host
+  attribute updates on the Check_MK server to avoid possible firewall issues.
+  [ganto_]
+
+Fixed
+~~~~~
+
+- Correctly use Ansible `changed` task filter. [ganto_]
+
 
 `debops-contrib.checkmk_agent v0.1.1` - 2017-01-23
 --------------------------------------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -36,7 +36,7 @@ Changed
 Fixed
 ~~~~~
 
-- Correctly use Ansible `changed` task filter. [ganto_]
+- Correctly use Ansible `changed` and `skipped` task filters. [ganto_]
 
 
 `debops-contrib.checkmk_agent v0.1.1` - 2017-01-23

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -40,7 +40,8 @@ checkmk_agent__allow: []
 # .. envvar:: checkmk_agent__server [[[
 #
 # Ansible inventory name of Check_MK server. By default it will be autodetected
-# via `debops_service_checkmk_server` host group configuration.
+# via `debops_service_checkmk_server` host group configuration. If the Check_MK
+# server is not managed by Ansible, set this to `False`.
 checkmk_agent__server: '{{ groups["debops_service_checkmk_server"][0]
                            if ("debops_service_checkmk_server" in groups) and
                               (groups["debops_service_checkmk_server"] | length > 0)
@@ -65,7 +66,10 @@ checkmk_agent__site: '{{ hostvars[checkmk_agent__server].ansible_local.checkmk_s
                                                                    # ]]]
 # .. envvar:: checkmk_agent__autojoin [[[
 #
-# Automatically add agent host to the Check_MK monitoring site.
+# Automatically add agent host to the Check_MK monitoring site. If the Check_MK
+# server is not managed by Ansible and you want automated agent registration to
+# work, manually define at least :envvar:`checkmk_agent__autojoin_url`,
+# :envvar:`checkmk_agent__autojoin_secret` and :envvar:`checkmk_agent__user_key`.
 checkmk_agent__autojoin: '{{ True if checkmk_agent__autojoin_url else False }}'
 
                                                                    # ]]]

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -37,14 +37,20 @@ checkmk_agent__allow: []
 # Monitoring site integration [[[
 # -------------------------------
 
+# .. envvar:: checkmk_agent__server_inventory_group [[[
+#
+# Ansible inventory host group used to lookup the Check_MK server.
+checkmk_agent__server_inventory_group: 'debops_service_checkmk_server'
+
+                                                                   # ]]]
 # .. envvar:: checkmk_agent__server [[[
 #
 # Ansible inventory name of Check_MK server. By default it will be autodetected
-# via `debops_service_checkmk_server` host group configuration. If the Check_MK
-# server is not managed by Ansible, set this to `False`.
-checkmk_agent__server: '{{ groups["debops_service_checkmk_server"][0]
-                           if ("debops_service_checkmk_server" in groups) and
-                              (groups["debops_service_checkmk_server"] | length > 0)
+# via :envvar:`checkmk_agent__server_inventory_group` host group configuration.
+# If the Check_MK server is not managed by Ansible, set this to `False`.
+checkmk_agent__server: '{{ groups[checkmk_agent__server_inventory_group][0]
+                           if (checkmk_agent__server_inventory_group in groups) and
+                              (groups[checkmk_agent__server_inventory_group] | length > 0)
                            else "" }}'
 
                                                                    # ]]]

--- a/tasks/autojoin.yml
+++ b/tasks/autojoin.yml
@@ -64,9 +64,9 @@
   uri:
     url: '{{ checkmk_agent__autojoin_url }}?action=activate_changes&_username={{ checkmk_agent__autojoin_user }}&_secret={{ checkmk_agent__autojoin_secret }}&output_format=json'
     return_content: yes
-  when: '{{ checkmk_agent__register_add_host.changed|d(False) or
-            checkmk_agent__register_update_host.changed|d(False) or
-            checkmk_agent__register_discover_services.changed|d(False) }}'
+  when: '{{ (checkmk_agent__register_add_host | changed) or
+            (checkmk_agent__register_update_host | changed) or
+            (checkmk_agent__register_discover_services | changed) }}'
   register: checkmk_agent__register_activate
   changed_when: ("json" in checkmk_agent__register_activate) and
                 (checkmk_agent__register_activate.json.result_code == 0)

--- a/tasks/autojoin.yml
+++ b/tasks/autojoin.yml
@@ -51,6 +51,7 @@
     method: 'POST'
     body: 'request={ "hostname": "{{ checkmk_agent__hostname }}" }'
     return_content: yes
+    timeout: 120
   when: '{{ checkmk_agent__discovery_mode|d() in [ "new", "remove", "fixall", "refresh" ] }}'
   register: checkmk_agent__register_discover_services
   changed_when: ("json" in checkmk_agent__register_discover_services) and
@@ -64,6 +65,7 @@
   uri:
     url: '{{ checkmk_agent__autojoin_url }}?action=activate_changes&_username={{ checkmk_agent__autojoin_user }}&_secret={{ checkmk_agent__autojoin_secret }}&output_format=json'
     return_content: yes
+    timeout: 120
   when: '{{ (checkmk_agent__register_add_host | changed) or
             (checkmk_agent__register_update_host | changed) or
             (checkmk_agent__register_discover_services | changed) }}'

--- a/tasks/autojoin.yml
+++ b/tasks/autojoin.yml
@@ -13,6 +13,7 @@
     method: 'POST'
     body: 'request={ "hostname": "{{ checkmk_agent__hostname }}" }'
     return_content: yes
+  delegate_to: '{{ checkmk_agent__server if checkmk_agent__server else omit }}'
   register: checkmk_agent__register_get_host
   always_run: True
   changed_when: False
@@ -24,6 +25,7 @@
     method: 'POST'
     body: 'request={ "hostname": "{{ checkmk_agent__hostname }}", "folder": "/", "attributes": {{ checkmk_agent__fact_host_attributes|to_json }} }'
     return_content: yes
+  delegate_to: '{{ checkmk_agent__server if checkmk_agent__server else omit }}'
   when: '{{ checkmk_agent__register_get_host.json.result == "No such host" }}'
   register: checkmk_agent__register_add_host
   changed_when: ("json" in checkmk_agent__register_add_host) and
@@ -37,6 +39,7 @@
     method: 'POST'
     body: 'request={ "hostname": "{{ checkmk_agent__hostname }}", "attributes": {{ checkmk_agent__fact_host_attributes|to_json }} }'
     return_content: yes
+  delegate_to: '{{ checkmk_agent__server if checkmk_agent__server else omit }}'
   when: '{{ checkmk_agent__register_add_host.skipped|d(False) and
            (not checkmk_agent__host_attributes|to_nice_json == checkmk_agent__register_get_host.json.result.attributes|d({})|to_nice_json) }}'
   register: checkmk_agent__register_update_host
@@ -52,6 +55,7 @@
     body: 'request={ "hostname": "{{ checkmk_agent__hostname }}" }'
     return_content: yes
     timeout: 120
+  delegate_to: '{{ checkmk_agent__server if checkmk_agent__server else omit }}'
   when: '{{ checkmk_agent__discovery_mode|d() in [ "new", "remove", "fixall", "refresh" ] }}'
   register: checkmk_agent__register_discover_services
   changed_when: ("json" in checkmk_agent__register_discover_services) and
@@ -66,6 +70,7 @@
     url: '{{ checkmk_agent__autojoin_url }}?action=activate_changes&_username={{ checkmk_agent__autojoin_user }}&_secret={{ checkmk_agent__autojoin_secret }}&output_format=json'
     return_content: yes
     timeout: 120
+  delegate_to: '{{ checkmk_agent__server if checkmk_agent__server else omit }}'
   when: '{{ (checkmk_agent__register_add_host | changed) or
             (checkmk_agent__register_update_host | changed) or
             (checkmk_agent__register_discover_services | changed) }}'

--- a/tasks/autojoin.yml
+++ b/tasks/autojoin.yml
@@ -40,8 +40,8 @@
     body: 'request={ "hostname": "{{ checkmk_agent__hostname }}", "attributes": {{ checkmk_agent__fact_host_attributes|to_json }} }'
     return_content: yes
   delegate_to: '{{ checkmk_agent__server if checkmk_agent__server else omit }}'
-  when: '{{ checkmk_agent__register_add_host.skipped|d(False) and
-           (not checkmk_agent__host_attributes|to_nice_json == checkmk_agent__register_get_host.json.result.attributes|d({})|to_nice_json) }}'
+  when: '{{ (checkmk_agent__register_add_host | skipped) and
+            (not checkmk_agent__host_attributes|to_nice_json == checkmk_agent__register_get_host.json.result.attributes|d({})|to_nice_json) }}'
   register: checkmk_agent__register_update_host
   changed_when: ("json" in checkmk_agent__register_update_host) and
                 (checkmk_agent__register_update_host.json.result_code == 0)


### PR DESCRIPTION
- Make agent registration work even when the host cannot directly access the Check_MK server WebAPI
- Allow to specify custom inventory host group name for Check_MK server lookup
- Correctly use the `changed` filter