### PR TITLE
Ensure that check_mk repo on the Ansible controller is user owned

### DIFF
--- a/tasks/setup_plugins.yml
+++ b/tasks/setup_plugins.yml
@@ -21,6 +21,7 @@
     update: True
   tags: [ 'role::checkmk_agent:plugins:get' ]
   delegate_to: '{{ checkmk_agent__git_dest_host }}'
+  become: '{{ False if (checkmk_agent__git_dest_host == "localhost") else True }}'
   run_once: True
 
 - name: Install Check_MK plugins


### PR DESCRIPTION
Previously, because the git task was delegated to localhost (when configured) and the playbook is run with `become` the files would be owned by the become_user (root) which is uncommon in DebOps.

Fixes: #30